### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Python Web Scraper
-Simple html webscraper template made for newegg.ca. Writes scraped data into a microsoft excel doc. Was made fairly quickly to compare cpu prices between AMD and Intel during a store sale. Resulting in not being as robust as it should be. However, scaling this script should be easy and I'll come back to it when I have time. 
+This program is an HTML web scraper template made for newegg.ca, which writes scraped data into a Microsoft excel document. 
+This web scraper was made to compare CPU prices between AMD and Intel during a store sale. Future plans for this program involve scaling and increasing robustness.
+
 
 Written By: Rusty
 


### PR DESCRIPTION
Line 2: "Simple html webscraper template made for newegg.ca. Writes scraped data into a microsoft excel doc" 
-> "This program is an HTML web scraper template made for newegg.ca, which writes scraped data into a Microsoft excel document" (Combined both sentences because the second sentence was an add-on to the first sentence).

Line 2: "Was made fairly quickly to compare cpu prices between AMD and Intel during a store sale. Resulting in not being as robust as it should be. However, scaling this script should be easy and I'll come back to it when I have time"
-> "This web scraper was made to compare CPU prices between AMD and Intel during a store sale. Future plans for this program involve scaling and increasing robustness" (Improved concision and removed discourse marker).